### PR TITLE
Update mqResourceAttributes.mappings

### DIFF
--- a/src/main/scripts/resourceMappings/mqResourceAttributes.mappings
+++ b/src/main/scripts/resourceMappings/mqResourceAttributes.mappings
@@ -277,16 +277,16 @@
                     "attrDataType": "keyword",
 					"attrMapping": "GET",
 					"attrValueMappings": {
-						"false": "DISABLED",
-						"true": "ENABLED"
+						"false": "ENABLED",
+						"true": "DISABLED"
 					}
 				},
 				"inhibitPut": {
                     "attrDataType": "keyword",
 					"attrMapping": "PUT",
 					"attrValueMappings": {
-						"false": "DISABLED",
-						"true": "ENABLED"
+						"false": "ENABLED",
+						"true": "DISABLED"
 					}
 				},
 				"isTransmissionQueue": {


### PR DESCRIPTION
The true and false mapping values for inhibitGet and inhibitPut were originally coded in reverse. They are now coded correctly.